### PR TITLE
Update presentz-1.3.1.js

### DIFF
--- a/dist/presentz-1.3.1.js
+++ b/dist/presentz-1.3.1.js
@@ -356,7 +356,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         listeners = this.presentz.listeners.play;
       } else if (this.isInPauseState || this.isInFinishState) {
         this.presentz.stopTimeChecker();
-        if (this.isInPauseState) {
+        if (this.isInPauseState && !this.isInFinishState) {
           listeners = this.presentz.listeners.pause;
         } else if (this.isInFinishState) {
           listeners = this.presentz.listeners.finish;


### PR DESCRIPTION
Fix for when you stop the video and it's not in loop. Now it's calling the listener when you finish and stop, before was calling the pause listener